### PR TITLE
ADD data service connectivity using podtracer gRPC destination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	podman build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	podman push ${IMG}
 
 ##@ Deployment
 

--- a/apis/job/v1alpha1/snoopyjob_types.go
+++ b/apis/job/v1alpha1/snoopyjob_types.go
@@ -44,6 +44,12 @@ type SnoopyJobSpec struct {
 	// Timer sets how much time to run the specified command.
 	// Valid example values are 10s, 2m, 1h etc.
 	Timer string `json:"timer,omitempty"`
+
+	// Ip address for the DataEndpoint where to send collected data
+	DataServiceIP string `json:"dataServiceIP,omitempty"`
+
+	// Port used by the data service on the data endpoint
+	DataServicePort string `json:"dataServicePort,omitempty"`
 }
 
 // SnoopyJobStatus defines the observed state of SnoopyJob

--- a/config/crd/bases/job.fennecproject.io_snoopyjobs.yaml
+++ b/config/crd/bases/job.fennecproject.io_snoopyjobs.yaml
@@ -45,6 +45,13 @@ spec:
                   in the context of a Pod Warning: The command must be present in
                   the used potracer image for it to be used'
                 type: string
+              dataServiceIP:
+                description: Ip address for the DataEndpoint where to send collected
+                  data
+                type: string
+              dataServicePort:
+                description: Port used by the data service on the data endpoint
+                type: string
               labelSelector:
                 additionalProperties:
                   type: string

--- a/config/rbac/role_scc.yaml
+++ b/config/rbac/role_scc.yaml
@@ -23,7 +23,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: snoopy-operator-scc-priv
+  name: role-scc-privileged
 subjects:
   - kind: ServiceAccount
     name: snoopy-operator-sa

--- a/config/samples/job_v1alpha1_snoopyjob.yaml
+++ b/config/samples/job_v1alpha1_snoopyjob.yaml
@@ -4,10 +4,11 @@ metadata:
   name: snoopy-samplejob
 spec:
   command: "tcpdump"
-  args: "-i eth0"
+  args: "-n -i eth0"
   labelSelector: { 
     networkMonitor: "true",
     }
   targetNamespace: cnf-telco
-  schedule: "*/2 * * * *"
-  timer: "60s"
+  timer: "2m"
+  dataServiceIP: "172.30.233.114"
+  dataServicePort: "51001"

--- a/controllers/job/constants.go
+++ b/controllers/job/constants.go
@@ -2,5 +2,5 @@ package job
 
 const (
 	serviceAccountName = "snoopy-operator-sa"
-	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-8"
+	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-10"
 )

--- a/controllers/job/reconcilers.go
+++ b/controllers/job/reconcilers.go
@@ -157,6 +157,13 @@ func (r *SnoopyJobReconciler) buildPodtracerOptions(snoopyJob *jobv1alpha1.Snoop
 		podtracerOpts = append(podtracerOpts, snoopyJob.Spec.Timer)
 	}
 
+	if snoopyJob.Spec.DataServiceIP != "" {
+		podtracerOpts = append(podtracerOpts, "-d")
+		podtracerOpts = append(podtracerOpts, snoopyJob.Spec.DataServiceIP)
+		podtracerOpts = append(podtracerOpts, "-p")
+		podtracerOpts = append(podtracerOpts, snoopyJob.Spec.DataServicePort)
+	}
+
 	return podtracerOpts
 }
 


### PR DESCRIPTION
This commit includes:
- podtracer options to communicate with the gRPC server
- new fields with those options on the CRD
- fixes to RBAC manifests to use make deploy as a deployment method
- replaces docker by podman in the Makefile