### PR TITLE
REMOVE pcap volume mount

### DIFF
--- a/config/samples/job_v1alpha1_snoopyjob.yaml
+++ b/config/samples/job_v1alpha1_snoopyjob.yaml
@@ -10,5 +10,5 @@ spec:
     }
   targetNamespace: cnf-telco
   timer: "2m"
-  dataServiceIP: "172.30.228.157"
+  dataServiceIP: "172.30.161.153"
   dataServicePort: "51001"

--- a/controllers/job/constants.go
+++ b/controllers/job/constants.go
@@ -2,5 +2,5 @@ package job
 
 const (
 	serviceAccountName = "snoopy-operator-sa"
-	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-10"
+	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-11"
 )

--- a/controllers/job/jobs.go
+++ b/controllers/job/jobs.go
@@ -123,12 +123,6 @@ func (r *SnoopyJobReconciler) JobTemplateSpec(podtracerArgsList []string, target
 						{Name: "crio-sock",
 							MountPath: "/var/run/crio/crio.sock",
 							ReadOnly:  false},
-						{Name: "pcap-data",
-							MountPath: "/pcap-data",
-							ReadOnly:  false},
-						// {Name: "kubeconfig",
-						// 	MountPath: "/root/.kube",
-						// 	ReadOnly:  false},
 					},
 				},
 			},
@@ -147,20 +141,6 @@ func (r *SnoopyJobReconciler) JobTemplateSpec(podtracerArgsList []string, target
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/var/run/crio/crio.sock",
 							Type: &HostPathSocket,
-						},
-					},
-				},
-				{
-					Name: "pcap-data",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: "kubeconfig",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "podtracer-kubeconfig",
 						},
 					},
 				},


### PR DESCRIPTION
removed pcap data mount and kubeconfig is no longer used in job deployments.
closes #36 
