### PR TITLE
ADD rsync capabilities to snoopy data endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= fennecproject.io/snoopy-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/fennec-project/snoopy-operator:0.0.1
+IMG ?= quay.io/fennec-project/snoopy-operator:0.0.1-2
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/config/samples/job_v1alpha1_snoopyjob.yaml
+++ b/config/samples/job_v1alpha1_snoopyjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: snoopy-samplejob
 spec:
   command: "tcpdump"
-  args: "-n -i eth0"
+  args: "-i eth0 -U -w -"
   labelSelector: { 
     networkMonitor: "true",
     }
   targetNamespace: cnf-telco
-  timer: "2m"
-  dataServiceIP: "172.30.161.153"
+  timer: "30s"
+  dataServiceIP: "172.30.30.60"
   dataServicePort: "51001"

--- a/controllers/data/constants.go
+++ b/controllers/data/constants.go
@@ -2,5 +2,5 @@ package data
 
 const (
 	serviceAccountName = "snoopy-operator-sa"
-	dataEndpointImage  = "quay.io/fennec-project/snoopy-data-endpoint:0.0.1"
+	dataEndpointImage  = "quay.io/fennec-project/snoopy-data-endpoint:0.0.1-4"
 )

--- a/controllers/job/constants.go
+++ b/controllers/job/constants.go
@@ -2,5 +2,5 @@ package job
 
 const (
 	serviceAccountName = "snoopy-operator-sa"
-	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-11"
+	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-12"
 )

--- a/endpoint/Makefile
+++ b/endpoint/Makefile
@@ -1,6 +1,12 @@
 
 all: client server
 
+podman-build:
+	podman build ./server/ -t quay.io/fennec-project/snoopy-data-endpoint:0.0.1-4
+
+podman-push:
+	podman push quay.io/fennec-project/snoopy-data-endpoint:0.0.1-4
+
 protoc:
 	@echo "Generating Go files"
 	cd proto && protoc --go_out=. --go-grpc_out=. \

--- a/endpoint/server/Dockerfile
+++ b/endpoint/server/Dockerfile
@@ -1,4 +1,7 @@
 FROM nicolaka/netshoot:latest
 WORKDIR /
-COPY server .
 USER root:root
+
+RUN mkdir -p /pcap && \
+apk add --no-cache rsync
+COPY server .

--- a/endpoint/server/server.go
+++ b/endpoint/server/server.go
@@ -52,7 +52,7 @@ func (s server) ExportPodData(srv pb.DataEndpoint_ExportPodDataServer) error {
 		// log.Printf("Received data for pod %v", pd.Name)
 
 		// open a file to write and append podData
-		f, err := os.OpenFile(pd.Name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile("/pcap/"+pd.Name, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
 		if err != nil {
 			fmt.Print(err.Error())
 			log.Fatal("Error openning file to write data on server.")


### PR DESCRIPTION
Bumped snoopy operator to 0.0.1-2
Bumped podtracerImage to 0.0.1-12 (Fixes the stderr going to the bin output)
Bumped snoopy-data-endpoint to 0.0.1-4 (Fixes file opening mode and flags for writing)
Added targets on endpoint makefile to build and push container images
Added rsync to endpoint server image to allow remote file syncing
Added parameters to snoopy sample job:
-U to avoid breaking packets in multiple parts
-w with "-" which writes the raw binary packet data to Stdout