### PR TITLE
Remove crd v1beta1 options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/fennec-project/snoopy-operator:0.0.1-2
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Change to makefile variable CRD_OPTIONS to remove defaults which apply only to v1beta1 CRDs and are not compatible with current versions of controller-tools