### PR TITLE
ALLOW snoopy-operator to always get the latest release of podtracer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= fennecproject.io/snoopy-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/fennec-project/snoopy-operator:0.0.1-14
+IMG ?= quay.io/fennec-project/snoopy-operator:0.0.1-15
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 

--- a/controllers/job/constants.go
+++ b/controllers/job/constants.go
@@ -2,5 +2,5 @@ package job
 
 const (
 	serviceAccountName = "snoopy-operator-sa"
-	podtracerImage     = "quay.io/fennec-project/podtracer:0.0.1-14"
+	podtracerImage     = "quay.io/fennec-project/podtracer:latest"
 )


### PR DESCRIPTION
With that we don't need to align or wait for podtracer to have a new version.
Snoopy-operator will always work on the latest version of podtracer that should
be the status of the master branch.

Any features included in podtracer will be immediately available for snoopy-operator.

closes #71 